### PR TITLE
update exit status

### DIFF
--- a/src_test/1_check_input/check_input_test.c
+++ b/src_test/1_check_input/check_input_test.c
@@ -6,7 +6,7 @@
 /*   By: aschenk <aschenk@student.42berlin.de>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/24 22:36:32 by aschenk           #+#    #+#             */
-/*   Updated: 2024/08/05 19:10:00 by aschenk          ###   ########.fr       */
+/*   Updated: 2024/08/12 17:30:00 by aschenk          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,7 +57,7 @@ ft_itoa fails). Also updates the `errno` to a custom `errno`.
  @param str_j 	Quotation symbol (' or ").
  @param i_str 	The string representation of position of piping syntax error.
 */
-static void	print_open_quotation_err_msg(char *char_str, char *i_str)
+static void	print_open_quotation_err_msg(char *char_str, char *i_str, t_data *data)
 {
 	ft_putstr_fd(ERR_COLOR, STDERR_FILENO); // Set error color for the output
 	ft_putstr_fd(ERR_PREFIX, STDERR_FILENO);
@@ -67,7 +67,7 @@ static void	print_open_quotation_err_msg(char *char_str, char *i_str)
 	ft_putstr_fd(i_str, STDERR_FILENO);
 	ft_putstr_fd(")\n", STDERR_FILENO);
 	ft_putstr_fd(RESET, STDERR_FILENO); // Reset the output style to default
-	errno = 420; // custom minishell exit status, bash would not return an error for unclosed quotations
+	data->exit_status = 420; // custom minishell exit status, bash would not return an error for unclosed quotations
 }
 
 /**
@@ -97,10 +97,10 @@ static int	is_closed(t_data *data, int i, const char c)
 	if (!i_str)
 	{
 		print_err_msg(ERR_MALLOC);
-		print_open_quotation_err_msg(char_str, "-1");
+		print_open_quotation_err_msg(char_str, "-1", data);
 		return (0); // Quotation mark is not closed, pos: -1
 	}
-	print_open_quotation_err_msg(char_str, i_str);
+	print_open_quotation_err_msg(char_str, i_str, data);
 	free(i_str);
 	return (0); // Quotation mark is not closed
 }

--- a/src_test/2_tokenizer/tokenizer_pipe_test.c
+++ b/src_test/2_tokenizer/tokenizer_pipe_test.c
@@ -6,7 +6,7 @@
 /*   By: aschenk <aschenk@student.42berlin.de>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/01 16:34:21 by aschenk           #+#    #+#             */
-/*   Updated: 2024/08/05 19:11:30 by aschenk          ###   ########.fr       */
+/*   Updated: 2024/08/12 17:40:38 by aschenk          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -78,7 +78,7 @@ and updates the `errno` accordingly.
  @param invalid_syn The invalid operand encountered in the input.
  @param str_j 		The string representation of int j (position of failed piping).
 */
-static void	print_pipe_err_msg(char *invalid_syn, char *str_j)
+static void	print_pipe_err_msg(char *invalid_syn, char *str_j, t_data *data)
 {
 	ft_putstr_fd(ERR_COLOR, STDERR_FILENO); // Set error color for the output
 	ft_putstr_fd(ERR_PREFIX, STDERR_FILENO);
@@ -89,7 +89,7 @@ static void	print_pipe_err_msg(char *invalid_syn, char *str_j)
 	ft_putstr_fd(str_j, STDERR_FILENO); // Print the position of failed redirection
 	ft_putstr_fd(")\n", STDERR_FILENO);
 	ft_putstr_fd(RESET, STDERR_FILENO); // Reset the output style to default
-	errno = ENOENT;
+	data->exit_status = ENOENT;
 }
 
 /**
@@ -100,7 +100,7 @@ and updates the `errno` accordingly.
 
  @param str_j The string representation of int j (position of failed piping).
 */
-static void	print_empty_pipe_err_msg(char *str_j)
+static void	print_empty_pipe_err_msg(char *str_j, t_data *data)
 {
 	ft_putstr_fd(ERR_COLOR, STDERR_FILENO); // Set error color for the output
 	ft_putstr_fd(ERR_PREFIX, STDERR_FILENO);
@@ -109,7 +109,7 @@ static void	print_empty_pipe_err_msg(char *str_j)
 	ft_putstr_fd(str_j, STDERR_FILENO); // Print the position of failed redirection
 	ft_putstr_fd(")\n", STDERR_FILENO);
 	ft_putstr_fd(RESET, STDERR_FILENO); // Reset the output style to default
-	errno = ENOENT;
+	data->exit_status = ENOENT;
 }
 
 /**
@@ -142,9 +142,9 @@ static int	check_syntax(t_data *data, int j)
 		if (ft_strcmp(str_j, "-1") == 0 || ft_strcmp(invalid_syn, "ERR") == 0) // print ERR_MALLOC if fallback values are used
 			print_err_msg(ERR_MALLOC);
 		if (data->tok.tok_lst == NULL)
-			print_empty_pipe_err_msg(str_j);
+			print_empty_pipe_err_msg(str_j, data);
 		else
-			print_pipe_err_msg(invalid_syn, str_j);
+			print_pipe_err_msg(invalid_syn, str_j, data);
 		if (invalid_syn && ft_strcmp(invalid_syn, "ERR") != 0)
 			free(invalid_syn);
 		if (ft_strcmp(str_j, "-1") != 0)

--- a/src_test/2_tokenizer/tokenizer_redirection_test.c
+++ b/src_test/2_tokenizer/tokenizer_redirection_test.c
@@ -6,7 +6,7 @@
 /*   By: aschenk <aschenk@student.42berlin.de>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/17 13:00:24 by aschenk           #+#    #+#             */
-/*   Updated: 2024/08/05 19:13:08 by aschenk          ###   ########.fr       */
+/*   Updated: 2024/08/12 17:36:36 by aschenk          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -81,27 +81,27 @@ and updates the `errno` accordingly.
  @param str_j 		The string representation of int j.
  @param j 			Position index of the failed redirection in the input string.
 */
-static void	print_redir_err_msg(char *invalid_op, const char *input,
+static void	print_redir_err_msg(char *invalid_op, t_data *data,
 	char *str_j, int j)
 {
 	ft_putstr_fd(ERR_COLOR, STDERR_FILENO); // Set error color for the output
 	ft_putstr_fd(ERR_PREFIX, STDERR_FILENO);
 	ft_putstr_fd(ERR_SYNTAX, STDERR_FILENO);
 	// Print the specific redirection operator encountered
-	if (input[j] == '>' && input[j + 1] == '>')
+	if (data->input[j] == '>' && data->input[j + 1] == '>')
 		ft_putstr_fd("'>>': '", STDERR_FILENO);
-	else if (input[j] == '>')
+	else if (data->input[j] == '>')
 		ft_putstr_fd("'>': '", STDERR_FILENO);
-	else if (input[j] == '<' && input[j + 1] == '<')
+	else if (data->input[j] == '<' && data->input[j + 1] == '<')
 		ft_putstr_fd("'<<': '", STDERR_FILENO);
-	else if (input[j] == '<')
+	else if (data->input[j] == '<')
 		ft_putstr_fd("'<': '", STDERR_FILENO);
 	ft_putstr_fd(invalid_op, STDERR_FILENO); // Print the invalid operand
 	ft_putstr_fd("' (position: ", STDERR_FILENO);
 	ft_putstr_fd(str_j, STDERR_FILENO); // Print the position of failed redirection
 	ft_putstr_fd(")\n", STDERR_FILENO);
 	ft_putstr_fd(RESET, STDERR_FILENO); // Reset the output style to default
-	errno = ENOENT;
+	data->exit_status = ENOENT;
 }
 
 /**
@@ -120,12 +120,12 @@ in these cases).
  @return	`0` if an invalid operand is found and an error message is printed.
 			`1` if the operand is valid.
 */
-static int	check_operand(const char *input, int *i, int j)
+static int	check_operand(t_data *data, int *i, int j)
 {
 	char	*invalid_op; // String for the invalid operand
 	char	*str_j; // String to hold the position of failed redirection
 
-	invalid_op = is_valid_operand(input, i); // Check if the operand is valid
+	invalid_op = is_valid_operand(data->input, i); // Check if the operand is valid
 	if (invalid_op) // If an invalid operand is found
 	{
 		str_j = ft_itoa(j);
@@ -133,12 +133,12 @@ static int	check_operand(const char *input, int *i, int j)
 			print_err_msg(ERR_MALLOC);
 		if (!str_j)
 		{
-			print_redir_err_msg(invalid_op, input, "-1", j);
+			print_redir_err_msg(invalid_op, data, "-1", j);
 			if (ft_strcmp(invalid_op, "ERR") != 0) // check if invalid_op was dynamically allocated
 				free(invalid_op);
 			return (0); // Invalid syntax was found, pos: -1
 		}
-		print_redir_err_msg(invalid_op, input, str_j, j);
+		print_redir_err_msg(invalid_op, data, str_j, j);
 		if (ft_strcmp(invalid_op, "ERR") != 0) // check if invalid_op was dynamically allocated
 			free(invalid_op);
 		free(str_j);
@@ -205,7 +205,7 @@ int	is_redirection(t_data *data, int *i)
 	// Check if a redirection was found and validate its operand
 	if (j != *i) // If *i has been incremented, it means a redirection was found
 	{
-		if (!check_operand(data->input, i, j))
+		if (!check_operand(data, i, j))
 			return (-1); // The operand is invalid or token creation failed
 		if (token_created == 0)
 			return (0); // Malloc fail during token creation


### PR DESCRIPTION
update exit status in data struct when syntax error related to pipe or redicrection (exit: 2), as well as for unclosed quotes (exit: 420)