### PR TITLE
105 make prompt pretty

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   config.h                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: nholbroo <nholbroo@student.42.fr>          +#+  +:+       +#+        */
+/*   By: aschenk <aschenk@student.42berlin.de>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/07 16:54:03 by aschenk           #+#    #+#             */
-/*   Updated: 2024/08/14 10:12:16 by nholbroo         ###   ########.fr       */
+/*   Updated: 2024/11/29 13:24:42 by aschenk          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,8 +28,10 @@ used for terminal formatting, prompt definitions, history configurations etc.
 # define ORANGE			"\033[38;5;208m"
 # define BLUE 			"\033[34m"
 # define VIOLET 		"\033[35;1m"
+# define ESC1			"\001"
+# define ESC2			"\002"
 
-# define PROMPT			"🌈 minishell$ "
+# define PROMPT			ESC1 BOLD ORANGE ESC2 "🌈 minishell$ " ESC1 RESET ESC2
 # define HEREDOC_P		"> "
 
 // History: Override macros when invoking 'make':

--- a/include/config.h
+++ b/include/config.h
@@ -6,7 +6,7 @@
 /*   By: aschenk <aschenk@student.42berlin.de>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/07 16:54:03 by aschenk           #+#    #+#             */
-/*   Updated: 2024/11/29 13:24:42 by aschenk          ###   ########.fr       */
+/*   Updated: 2024/11/29 13:38:30 by aschenk          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,21 +18,20 @@ used for terminal formatting, prompt definitions, history configurations etc.
 #ifndef CONFIG_H
 # define CONFIG_H
 
-// Define ANSI escape codes for colors and styles
-# define RESET			"\033[0m"
-# define BOLD			"\033[1m"
-# define RED			"\033[31;2m"
-# define GREEN			"\033[32m"
-# define YELLOW			"\033[33m"
-# define L_RED			"\033[91m"
-# define ORANGE			"\033[38;5;208m"
-# define BLUE 			"\033[34m"
-# define VIOLET 		"\033[35;1m"
-# define ESC1			"\001"
-# define ESC2			"\002"
+// Define ANSI escape codes for colors and styles;
+// incl.escape sequences for marking non-printable characters (\001 and \002).
+# define RESET		"\001\033[0m\002"
+# define BOLD		"\001\033[1m\002"
+# define RED		"\001\033[31;2m\002"
+# define GREEN		"\001\033[32m\002"
+# define YELLOW		"\001\033[33m\002"
+# define L_RED		"\001\033[91m\002"
+# define ORANGE		"\001\033[38;5;208m\002"
+# define BLUE 		"\001\033[34m\002"
+# define VIOLET 	"\001\033[35;1m\002"
 
-# define PROMPT			ESC1 BOLD ORANGE ESC2 "🌈 minishell$ " ESC1 RESET ESC2
-# define HEREDOC_P		"> "
+# define PROMPT		"\001\033[1m\033[38;5;208m\002🌈 minishell$ \001\033[0m\002"
+# define HEREDOC_P	"> "
 
 // History: Override macros when invoking 'make':
 // 'make CFLAGS+="-DHIST_FILE='new_path' -DHIST_SIZE=42"


### PR DESCRIPTION
adding escape sequence markers for defining beginning and end of non-printable characters (/001 and /002, respectively) into the escape sequences for formatting constants did the trick to avoid issues with "wrongly sized" input fields sometimes occuring when  calling a long cmd from history.